### PR TITLE
Make parent:: not be reported as a static call

### DIFF
--- a/src/Dictionary.php
+++ b/src/Dictionary.php
@@ -18,7 +18,7 @@ class Dictionary
 			'Reflection', 'ReflectionFunctionAbstract', 'ReflectionFunction',
 			'ReflectionParameter', 'ReflectionMethod', 'ReflectionClass',
 			'ReflectionObject', 'ReflectionProperty', 'ReflectionExtension',
-			'ReflectionZendExtension', 'ZipArchive', 'PDO', 'XMLReader', 
+			'ReflectionZendExtension', 'ZipArchive', 'PDO', 'XMLReader',
 			'finfo', 'Phar', 'SoapClient', 'SoapServer', 'DOMDocument'
 		]);
 	}
@@ -43,11 +43,14 @@ class Dictionary
 		$className = strtolower ($className);
 
 		// does it have namespaces?
-		if (FALSE !== strpos ($className, '\\')) 
+		if (FALSE !== strpos ($className, '\\'))
 		{
 			return false;
 		}
-
+		if ($className === 'parent')
+		{
+			return true;
+		}
 		// check if it's in the black list
 		if (in_array ($className, $this->unsafeForInstantiation))
 		{
@@ -57,7 +60,7 @@ class Dictionary
 		elseif (in_array ($className, array_map ('strtolower', get_declared_classes())))
 		{
 			return true;
-		}		
+		}
 
 		return false;
 	}

--- a/testFile.php
+++ b/testFile.php
@@ -3,7 +3,7 @@
 error_reporting (E_ALL);
 
 /**
- * This is a test file, with several issues that 
+ * This is a test file, with several issues that
  * should be reported by testability.
  */
 final class Whatever
@@ -11,7 +11,7 @@ final class Whatever
     public function methodMan ($x, $y, $z)
     {
         // globals, over multiple lines
-        global $boom, 
+        global $boom,
         	   $bass;
 
         // this variable can't be relied
@@ -24,7 +24,7 @@ final class Whatever
 
         // Static property of another class
        	$a = OtherClass::thing;
-        
+
         // Static property, same class
         $a = Whatever::thing;
 
@@ -66,7 +66,7 @@ final class Whatever
 
         // Callables (should be supported in the future)
         array_map ('Blah::something', array(1,2,3));
-       	
+
         // Static dynamic method call, another class
         $y = Utils::$name;
 
@@ -94,7 +94,7 @@ final class Whatever
     protected function privateParts2 ()
     {
         // this one too
-    } 
+    }
 
     final public function finalSucks ()
     {
@@ -104,7 +104,7 @@ final class Whatever
     /**
      * @codeCoverageIgnore
      */
-    private function immune () 
+    private function immune ()
     {
         global $y;
         $x = new Whatever (Things::thing);
@@ -117,7 +117,7 @@ final class Whatever
 function dothis()
 {
     global $diddy;
-    
+
     $y = new Whatever ();
     $y->methodMan();
 
@@ -135,7 +135,7 @@ function dothis()
 
     $varClass::method1();
 
-    try 
+    try
     {
         callThisFunc();
     }

--- a/tests/NodeVisitors/StaticCallVisitorTest.php
+++ b/tests/NodeVisitors/StaticCallVisitorTest.php
@@ -1,62 +1,90 @@
 <?php
 
-require_once __DIR__.'/../../vendor/autoload.php';
+require_once __DIR__ . '/../../vendor/autoload.php';
 use edsonmedina\php_testability\NodeVisitors\StaticCallVisitor;
 use edsonmedina\php_testability\Contexts\RootContext;
 use edsonmedina\php_testability\ContextStack;
 
 class StaticCallVisitorTest extends PHPUnit\Framework\TestCase
 {
-	/**
-	 * @covers edsonmedina\php_testability\NodeVisitors\StaticCallVisitor::leaveNode
-	 */
-	public function testLeaveNodeWithDifferentType ()
-	{
-		$context = new RootContext ('/');
+    /**
+     * @covers edsonmedina\php_testability\NodeVisitors\StaticCallVisitor::leaveNode
+     */
+    public function testLeaveNodeWithDifferentType()
+    {
+        $context = new RootContext ('/');
 
-		$stack = $this->getMockBuilder ('edsonmedina\php_testability\ContextStack')
-		              ->setConstructorArgs([$context])
-		              ->setMethods(['addIssue'])
-		              ->getMock();
+        $stack = $this->getMockBuilder('edsonmedina\php_testability\ContextStack')
+            ->setConstructorArgs([$context])
+            ->setMethods(['addIssue'])
+            ->getMock();
 
-		$stack->expects($this->never())->method('addIssue');
+        $stack->expects($this->never())->method('addIssue');
 
-		$wrongNode = $this->getMockBuilder ('PhpParser\Node\Expr\StaticCall')
-		                  ->disableOriginalConstructor()
-		                  ->getMock();
+        $wrongNode = $this->getMockBuilder('PhpParser\Node\Expr\StaticCall')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-		$node = $this->getMockBuilder('PhpParser\Node\Expr\Eval_')
-		             ->disableOriginalConstructor()
-		             ->getMock();
+        $node = $this->getMockBuilder('PhpParser\Node\Expr\Eval_')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-		$visitor = new StaticCallVisitor ($stack, $context);
-		$visitor->leaveNode ($node);
-	}
+        $visitor = new StaticCallVisitor ($stack, $context);
+        $visitor->leaveNode($node);
+    }
 
-	/**
-	 * @covers edsonmedina\php_testability\NodeVisitors\StaticCallVisitor::leaveNode
-	 */
-	public function testLeaveNodeInGlobalSpace ()
-	{
-		$context = new RootContext ('/');
+    /**
+     * @covers edsonmedina\php_testability\NodeVisitors\StaticCallVisitor::leaveNode
+     */
+    public function testLeaveNodeInGlobalSpace()
+    {
+        $context = new RootContext ('/');
 
-		$stack = $this->getMockBuilder('edsonmedina\php_testability\ContextStack')
-		              ->setConstructorArgs([$context])
-		              ->setMethods(['addIssue'])
-		              ->getMock();
+        $stack = $this->getMockBuilder('edsonmedina\php_testability\ContextStack')
+            ->setConstructorArgs([$context])
+            ->setMethods(['addIssue'])
+            ->getMock();
 
-		$stack->expects($this->never())->method('addIssue');
+        $stack->expects($this->never())->method('addIssue');
 
-		$node = $this->getMockBuilder ('PhpParser\Node\Expr\StaticCall')
-		             ->disableOriginalConstructor()
-		             ->getMock();
+        $node = $this->getMockBuilder('PhpParser\Node\Expr\StaticCall')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-		$visitor = $this->getMockBuilder('edsonmedina\php_testability\NodeVisitors\StaticCallVisitor')
-		                ->setConstructorArgs([$stack, $context])
-		                ->setMethods(['inGlobalScope'])
-		                ->getMock();
+        $visitor = $this->getMockBuilder('edsonmedina\php_testability\NodeVisitors\StaticCallVisitor')
+            ->setConstructorArgs([$stack, $context])
+            ->setMethods(['inGlobalScope'])
+            ->getMock();
 
-		$visitor->expects($this->once())->method('inGlobalScope')->willReturn (true);
-		$visitor->leaveNode ($node);
-	}
+        $visitor->expects($this->once())->method('inGlobalScope')->willReturn(true);
+        $visitor->leaveNode($node);
+    }
+
+    public function testLeaveNodeWithParentCall()
+    {
+        $context = new RootContext ('/');
+
+        $stack = $this->getMockBuilder('edsonmedina\php_testability\ContextStack')
+            ->setConstructorArgs([$context])
+            ->setMethods(['addIssue'])
+            ->getMock();
+
+        $stack->expects($this->never())->method('addIssue');
+        /** @var \PhpParser\Node\Expr\StaticCall $node */
+        $node = $this->getMockBuilder('PhpParser\Node\Expr\StaticCall')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $node->class = $this->getMockBuilder('PhpParser\Node\Name')->disableOriginalConstructor()->setMethods(['toString'])->getMock();
+        $node->class->parts = ['parent'];
+        $node->class->expects($this->once())->method('toString')->willReturn('parent');
+
+        $visitor = $this->getMockBuilder('edsonmedina\php_testability\NodeVisitors\StaticCallVisitor')
+            ->setConstructorArgs([$stack, $context])
+            ->setMethods(['inGlobalScope'])
+            ->getMock();
+
+        $visitor->expects($this->once())->method('inGlobalScope')->willReturn(false);
+
+        $visitor->leaveNode($node);
+    }
 }


### PR DESCRIPTION
Make testability able to work with single files